### PR TITLE
Enrich cards with Portuguese metadata

### DIFF
--- a/db.py
+++ b/db.py
@@ -90,6 +90,8 @@ class Card(db.Model):
     rarity: Mapped[Optional[str]] = mapped_column(db.String(50))
     type: Mapped[Optional[str]] = mapped_column(db.String(50))
     image_url: Mapped[Optional[str]] = mapped_column(db.String(500))
+    name_pt: Mapped[Optional[str]] = mapped_column(db.String(200), index=True)
+    image_url_pt: Mapped[Optional[str]] = mapped_column(db.String(500))
 
     set_id: Mapped[int] = mapped_column(
         ForeignKey("sets.id", ondelete="CASCADE"), nullable=False, index=True
@@ -124,10 +126,12 @@ class Card(db.Model):
         return {
             "id": self.id,
             "name": self.name,
+            "name_pt": self.name_pt,
             "number": self.number,
             "rarity": self.rarity,
             "type": self.type,
             "image_url": self.image_url,
+            "image_url_pt": self.image_url_pt,
             "set": self.set.as_dict() if self.set else None,
             "latest_price": self.latest_price(),
         }

--- a/pokemontcg_import.py
+++ b/pokemontcg_import.py
@@ -25,6 +25,8 @@ except Exception:
     Retry = None  # type: ignore
 
 from db import db, Set, Card
+from scrapers.ligapokemon_html import LigaPokemonHTMLScraper
+from liga_market import _build_queries as _br_queries
 
 API_BASE = "https://api.pokemontcg.io/v2"
 CARDS_EP = f"{API_BASE}/cards"
@@ -35,6 +37,7 @@ PAGE_SIZE = 50     # evita payloads gigantes
 
 # ========= Sessão HTTP com retries =========
 _SESSION: Optional[requests.Session] = None
+_PT_SCRAPER = LigaPokemonHTMLScraper()
 
 def _session() -> requests.Session:
     global _SESSION
@@ -127,6 +130,24 @@ def upsert_set(api_set: Dict) -> Set:
     db.session.flush()
     return s
 
+def _enrich_portuguese(card: Card) -> None:
+    """Preenche nome e imagem em PT-BR usando Liga Pokémon."""
+    if card.name_pt and card.image_url_pt:
+        return
+    queries = _br_queries(card)
+    for q in queries:
+        try:
+            results = _PT_SCRAPER.search(q)
+        except Exception:
+            continue
+        if not results:
+            continue
+        best = results[0]
+        card.name_pt = best.title[:200]
+        if best.image_url:
+            card.image_url_pt = best.image_url[:500]
+        break
+
 def upsert_card(api_card: Dict, s: Set) -> Card:
     """Cria/atualiza um Card local no Set informado."""
     name = api_card.get("name") or "?"
@@ -147,6 +168,10 @@ def upsert_card(api_card: Dict, s: Set) -> Card:
         c.rarity = rarity
         c.type = ctype
         c.image_url = image_url
+    try:
+        _enrich_portuguese(c)
+    except Exception:
+        pass
     db.session.flush()
     return c
 

--- a/scrapers/ligapokemon_html.py
+++ b/scrapers/ligapokemon_html.py
@@ -129,6 +129,19 @@ def _closest_tile_text(a_tag) -> str:
     return _clean(a_tag.get_text(" ", strip=True))
 
 
+def _closest_image_url(a_tag) -> Optional[str]:
+    """Tenta encontrar o <img> relacionado ao tile do link."""
+    node = a_tag
+    for _ in range(6):
+        if node is None:
+            break
+        img = node.find("img")
+        if img and img.get("src"):
+            return urljoin(BASE_URL, img.get("src"))
+        node = node.parent
+    return None
+
+
 def _detail_price(url: str, timeout: int = 15) -> Tuple[Optional[float], Optional[str]]:
     """
     Abre a página de detalhe e tenta extrair o preço visível.
@@ -197,6 +210,7 @@ class LigaPokemonHTMLScraper(BaseScraper):
                     title = _clean(a.get_text(" ").strip())
                     if not title:
                         title = block_text
+                    img_url = _closest_image_url(a)
 
                     # Preço no tile
                     price = _to_brl_float(block_text)
@@ -224,6 +238,7 @@ class LigaPokemonHTMLScraper(BaseScraper):
                         url=abs_url,
                         price_min_brl=price,
                         price_max_brl=price,
+                        image_url=img_url,
                     ).clamp()
 
                     results.append(pr)


### PR DESCRIPTION
## Summary
- add Portuguese name and image fields to Card model
- scrape Liga Pokémon listings to capture PT-BR titles and images
- populate Portuguese metadata during card import

## Testing
- `python -m pytest`
- `python -m py_compile db.py pokemontcg_import.py scrapers/ligapokemon_html.py`


------
https://chatgpt.com/codex/tasks/task_e_68b260f4b32083248cdd614ed17f442e