### PR TITLE
Enable Portuguese card search and display

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ from flask import (
     abort,
     Response,
 )
-from sqlalchemy import func, distinct
+from sqlalchemy import func, distinct, or_
 
 from config import Config
 from db import (
@@ -274,7 +274,10 @@ def create_app() -> Flask:
                 # Busca tolerante por nome (AND entre tokens simples)
                 raw_tokens, _ = _tokenize(q)
                 for t in raw_tokens:
-                    query = query.filter(Card.name.ilike(f"%{t}%"))
+                    query = query.filter(or_(
+                        Card.name.ilike(f"%{t}%"),
+                        Card.name_pt.ilike(f"%{t}%"),
+                    ))
 
         # Filtro por set
         if set_id:
@@ -347,7 +350,10 @@ def create_app() -> Flask:
                     query = Card.query
                     raw_tokens, _ = _tokenize(q)
                     for t in raw_tokens:
-                        query = query.filter(Card.name.ilike(f"%{t}%"))
+                        query = query.filter(or_(
+                            Card.name.ilike(f"%{t}%"),
+                            Card.name_pt.ilike(f"%{t}%"),
+                        ))
                     if set_id:
                         try:
                             query = query.filter(Card.set_id == int(set_id))
@@ -786,7 +792,10 @@ def create_app() -> Flask:
                 number = _normalize_print_number(q)
                 query = query.filter(Card.number == (number.split("/")[0] if "/" in number else number))
             else:
-                query = query.filter(Card.name.ilike(f"%{q}%"))
+                query = query.filter(or_(
+                    Card.name.ilike(f"%{q}%"),
+                    Card.name_pt.ilike(f"%{q}%"),
+                ))
         cards = query.order_by(Card.name.asc()).limit(50).all()
         if (not cards) and q:
             if _NUMBER_RE.match(q):
@@ -801,7 +810,10 @@ def create_app() -> Flask:
                     query = Card.query
                     raw, _ = _tokenize(q)
                     for t in raw:
-                        query = query.filter(Card.name.ilike(f"%{t}%"))
+                        query = query.filter(or_(
+                            Card.name.ilike(f"%{t}%"),
+                            Card.name_pt.ilike(f"%{t}%"),
+                        ))
                     cards = query.order_by(Card.name.asc()).limit(50).all()
         
         return jsonify([c.as_dict() for c in cards])

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -14,12 +14,14 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {% for it in items %}
         {% set c = it.card %}
-        {% set query = (c.name ~ ' ' ~ (c.set.name if c.set else '') ~ ' ' ~ (c.number or '')) %}
+        {% set display_name = c.name_pt or c.name %}
+        {% set img_url = c.image_url_pt or c.image_url %}
+        {% set query = (display_name ~ ' ' ~ (c.set.name if c.set else '') ~ ' ' ~ (c.number or '')) %}
         <article class="card p-3" data-card-id="{{ c.id }}" data-item-id="{{ it.id }}" data-query="{{ query|trim }}">
           <!-- Imagem -->
           <div class="relative">
-            {% if c and c.image_url %}
-              <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+            {% if c and img_url %}
+              <img src="{{ img_url }}" alt="Imagem de {{ display_name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
             {% else %}
               <div class="w-full aspect-[3/4] rounded-xl" style="background:#dfecc4; display:grid; place-items:center; color:#2c452c;">sem imagem</div>
             {% endif %}
@@ -28,7 +30,7 @@
 
           <!-- Títulos -->
           <div class="mt-3">
-            <h3 class="font-semibold leading-tight truncate" title="{{ c.name }}">{{ c.name }}</h3>
+            <h3 class="font-semibold leading-tight truncate" title="{{ display_name }}">{{ display_name }}</h3>
             <p class="text-xs text-slate-500 truncate">
               {% if c and c.set %}<a href="{{ url_for('set_view', set_id=c.set.id) }}" class="underline hover:no-underline">{{ c.set.name }}</a>{% else %}—{% endif %} • #{{ c.number or '—' }}
             </p>

--- a/templates/fontes.html
+++ b/templates/fontes.html
@@ -118,16 +118,18 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {% for c in results %}
         <article class="card p-3">
+          {% set display_name = c.name_pt or c.name %}
+          {% set img_url = c.image_url_pt or c.image_url %}
           <div class="relative">
-            {% if c.image_url %}
-              <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+            {% if img_url %}
+              <img src="{{ img_url }}" alt="Imagem de {{ display_name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
             {% else %}
               <div class="w-full aspect-[3/4] rounded-xl" style="background:#dfecc4; display:grid; place-items:center; color:#2c452c;">sem imagem</div>
             {% endif %}
           </div>
 
           <div class="mt-3">
-            <h3 class="font-semibold leading-tight truncate" title="{{ c.name }}">{{ c.name }}</h3>
+            <h3 class="font-semibold leading-tight truncate" title="{{ display_name }}">{{ display_name }}</h3>
             <p class="text-xs text-slate-500 truncate">
               {% if c.set %}<a href="{{ url_for('set_view', set_id=c.set.id) }}" class="underline hover:no-underline">{{ c.set.name }}</a>{% else %}—{% endif %} • #{{ c.number or '—' }}{% if c.rarity %} • {{ c.rarity }}{% endif %}
             </p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -139,10 +139,12 @@
     <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
       {% for i in recent %}
         <article class="card p-2">
+          {% set display_name = i.card.name_pt or i.card.name %}
+          {% set img_url = i.card.image_url_pt or i.card.image_url %}
           <div class="relative">
-            {% if i.card.image_url %}
-              <img src="{{ i.card.image_url }}"
-                   alt="Imagem de {{ i.card.name }}"
+            {% if img_url %}
+              <img src="{{ img_url }}"
+                   alt="Imagem de {{ display_name }}"
                    class="w-full aspect-[3/4] object-cover rounded-lg">
             {% else %}
               <div class="w-full aspect-[3/4] bg-slate-200 rounded-lg grid place-items-center text-slate-500">
@@ -153,7 +155,7 @@
           </div>
 
           <div class="mt-2">
-            <h3 class="text-sm font-semibold leading-tight truncate" title="{{ i.card.name }}">{{ i.card.name }}</h3>
+            <h3 class="text-sm font-semibold leading-tight truncate" title="{{ display_name }}">{{ display_name }}</h3>
             <p class="text-xs text-slate-500 truncate">
               {{ i.card.set.name }} • #{{ i.card.number or '—' }}
             </p>

--- a/templates/set_detail.html
+++ b/templates/set_detail.html
@@ -58,9 +58,11 @@
           <span class="text-sm text-slate-600">Selecionar</span>
         </label>
 
+        {% set display_name = c.name_pt or c.name %}
+        {% set img_url = c.image_url_pt or c.image_url %}
         <div class="relative mt-2">
-          {% if c.image_url %}
-            <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+          {% if img_url %}
+            <img src="{{ img_url }}" alt="Imagem de {{ display_name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
           {% else %}
             <div class="w-full aspect-[3/4] rounded-xl" style="border:1px dashed #d9e6d9; background:linear-gradient(120deg,#f8fcf8,#f1f6f1); display:grid; place-items:center; color:#2c452c;">sem imagem</div>
           {% endif %}
@@ -75,7 +77,7 @@
         </div>
 
         <div class="mt-3">
-          <h3 class="font-semibold leading-tight truncate" title="{{ c.name }}">{{ c.name }}</h3>
+          <h3 class="font-semibold leading-tight truncate" title="{{ display_name }}">{{ display_name }}</h3>
           <p class="text-xs text-slate-500 truncate">#{{ c.number or '—' }}{% if c.rarity %} • {{ c.rarity }}{% endif %}</p>
         </div>
       </article>

--- a/templates/wishlist.html
+++ b/templates/wishlist.html
@@ -17,14 +17,16 @@
 
         <article class="card p-3">
           <div class="flex gap-3">
-            {% if i.card.image_url %}
-              <img src="{{ i.card.image_url }}" alt="Imagem de {{ i.card.name }}" class="w-16 h-20 object-cover rounded">
+            {% set display_name = i.card.name_pt or i.card.name %}
+            {% set img_url = i.card.image_url_pt or i.card.image_url %}
+            {% if img_url %}
+              <img src="{{ img_url }}" alt="Imagem de {{ display_name }}" class="w-16 h-20 object-cover rounded">
             {% else %}
               <div class="w-16 h-20 bg-slate-200 rounded grid place-items-center text-slate-500 text-xs">sem<br>img</div>
             {% endif %}
 
             <div class="flex-1 min-w-0">
-              <h3 class="font-semibold leading-tight truncate" title="{{ i.card.name }}">{{ i.card.name }}</h3>
+              <h3 class="font-semibold leading-tight truncate" title="{{ display_name }}">{{ display_name }}</h3>
               <p class="text-xs text-slate-500 truncate">
                 {{ i.card.set.name }} • #{{ i.card.number or '—' }}
               </p>


### PR DESCRIPTION
## Summary
- search and autocomplete now match both English and Portuguese card names
- card listings prioritize localized names and images when available

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b26bb13e648324afbe44dfb49f9e2c