### PR TITLE
Adiciona esquema PostgreSQL do Pokémon TCG e script de população

### DIFF
--- a/database/esquema_tcg_ptbr.sql
+++ b/database/esquema_tcg_ptbr.sql
@@ -1,0 +1,145 @@
+-- Esquema PostgreSQL para o Pokémon TCG (PT-BR)
+-- Define tabelas, relacionamentos e índices para um banco de dados completo.
+
+CREATE TABLE series (
+    id SERIAL PRIMARY KEY,
+    nome VARCHAR(100) NOT NULL UNIQUE,
+    codigo VARCHAR(50),
+    data_lancamento DATE,
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    atualizado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+);
+
+CREATE TABLE colecoes (
+    id SERIAL PRIMARY KEY,
+    serie_id INTEGER NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+    nome VARCHAR(120) NOT NULL,
+    codigo VARCHAR(50),
+    data_lancamento DATE,
+    total_cartas INTEGER,
+    simbolo_url TEXT,
+    logo_url TEXT,
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    atualizado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    UNIQUE (serie_id, codigo)
+);
+
+CREATE INDEX idx_colecoes_nome ON colecoes (nome);
+
+CREATE TABLE raridades (
+    id SERIAL PRIMARY KEY,
+    nome VARCHAR(50) NOT NULL UNIQUE
+);
+
+CREATE TABLE artistas (
+    id SERIAL PRIMARY KEY,
+    nome VARCHAR(100) NOT NULL UNIQUE
+);
+
+CREATE TABLE tipos_energia (
+    id SERIAL PRIMARY KEY,
+    nome VARCHAR(50) NOT NULL UNIQUE,
+    simbolo VARCHAR(20)
+);
+
+CREATE TABLE cartas (
+    id SERIAL PRIMARY KEY,
+    colecao_id INTEGER NOT NULL REFERENCES colecoes(id) ON DELETE CASCADE,
+    nome VARCHAR(200) NOT NULL,
+    numero VARCHAR(20) NOT NULL,
+    hp INTEGER,
+    classe VARCHAR(50),
+    subclasse VARCHAR(50),
+    raridade_id INTEGER REFERENCES raridades(id),
+    artista_id INTEGER REFERENCES artistas(id),
+    regra VARCHAR(255),
+    texto_rodape TEXT,
+    publicado BOOLEAN DEFAULT TRUE,
+    criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    atualizado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    UNIQUE (colecao_id, numero)
+);
+
+CREATE INDEX idx_cartas_nome ON cartas (nome);
+CREATE INDEX idx_cartas_colecao ON cartas (colecao_id);
+
+CREATE TABLE habilidades (
+    id SERIAL PRIMARY KEY,
+    carta_id INTEGER NOT NULL REFERENCES cartas(id) ON DELETE CASCADE,
+    nome VARCHAR(100) NOT NULL,
+    texto TEXT NOT NULL,
+    ordem SMALLINT DEFAULT 0,
+    UNIQUE (carta_id, nome)
+);
+
+CREATE TABLE ataques (
+    id SERIAL PRIMARY KEY,
+    carta_id INTEGER NOT NULL REFERENCES cartas(id) ON DELETE CASCADE,
+    nome VARCHAR(100) NOT NULL,
+    texto TEXT,
+    dano VARCHAR(20),
+    ordem SMALLINT DEFAULT 0
+);
+
+CREATE TABLE ataques_custos (
+    ataque_id INTEGER REFERENCES ataques(id) ON DELETE CASCADE,
+    tipo_energia_id INTEGER REFERENCES tipos_energia(id),
+    quantidade SMALLINT NOT NULL CHECK (quantidade > 0),
+    PRIMARY KEY (ataque_id, tipo_energia_id)
+);
+
+CREATE TABLE fraquezas (
+    id SERIAL PRIMARY KEY,
+    carta_id INTEGER NOT NULL REFERENCES cartas(id) ON DELETE CASCADE,
+    tipo_energia_id INTEGER NOT NULL REFERENCES tipos_energia(id),
+    multiplicador VARCHAR(10) NOT NULL
+);
+
+CREATE TABLE resistencias (
+    id SERIAL PRIMARY KEY,
+    carta_id INTEGER NOT NULL REFERENCES cartas(id) ON DELETE CASCADE,
+    tipo_energia_id INTEGER NOT NULL REFERENCES tipos_energia(id),
+    modificador VARCHAR(10) NOT NULL
+);
+
+CREATE TABLE formatos_torneio (
+    id SERIAL PRIMARY KEY,
+    nome VARCHAR(50) NOT NULL UNIQUE
+);
+
+CREATE TABLE legalidades (
+    carta_id INTEGER REFERENCES cartas(id) ON DELETE CASCADE,
+    formato_id INTEGER REFERENCES formatos_torneio(id),
+    status VARCHAR(20) NOT NULL DEFAULT 'legal',
+    PRIMARY KEY (carta_id, formato_id)
+);
+
+CREATE TABLE variantes (
+    id SERIAL PRIMARY KEY,
+    carta_id INTEGER NOT NULL REFERENCES cartas(id) ON DELETE CASCADE,
+    tipo VARCHAR(50) NOT NULL,
+    descricao VARCHAR(100),
+    UNIQUE (carta_id, tipo)
+);
+
+CREATE TABLE imagens (
+    id SERIAL PRIMARY KEY,
+    carta_id INTEGER NOT NULL REFERENCES cartas(id) ON DELETE CASCADE,
+    variante_id INTEGER REFERENCES variantes(id),
+    url_pequena TEXT,
+    url_grande TEXT,
+    tipo VARCHAR(20)
+);
+
+CREATE TABLE precos (
+    id SERIAL PRIMARY KEY,
+    carta_id INTEGER NOT NULL REFERENCES cartas(id) ON DELETE CASCADE,
+    fonte VARCHAR(50) NOT NULL,
+    data_coleta DATE NOT NULL DEFAULT CURRENT_DATE,
+    preco_baixo NUMERIC(10,2),
+    preco_medio NUMERIC(10,2),
+    preco_alto NUMERIC(10,2),
+    preco_mercado NUMERIC(10,2)
+);
+
+CREATE INDEX idx_precos_carta_data ON precos (carta_id, data_coleta);

--- a/database/popular_bd.py
+++ b/database/popular_bd.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Script para criar e popular o banco de dados do Pokémon TCG em PT-BR.
+
+Uso:
+    python popular_bd.py
+O script lê a variável de ambiente `DATABASE_URL` para a conexão
+(como ``postgresql://usuario:senha@localhost:5432/pokemontcg``).
+"""
+
+import os
+from pathlib import Path
+from sqlalchemy import create_engine, text
+
+ARQUIVO_ESQUEMA = Path(__file__).with_name("esquema_tcg_ptbr.sql")
+
+ENERGIAS = [
+    ("Grama", "G"),
+    ("Fogo", "R"),
+    ("Água", "W"),
+    ("Raio", "L"),
+    ("Psíquico", "P"),
+    ("Luta", "F"),
+    ("Escuridão", "D"),
+    ("Metal", "M"),
+    ("Fada", "Y"),
+    ("Dragão", "N"),
+    ("Incolor", "C"),
+]
+
+RARIDADES = [
+    "Comum",
+    "Incomum",
+    "Rara",
+    "Rara Holo",
+    "Ultra Rara",
+    "Secreta",
+]
+
+
+def obter_engine():
+    url = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/pokemontcg")
+    return create_engine(url, echo=False)
+
+
+def criar_esquema(engine):
+    """Executa o arquivo SQL para criar todo o esquema."""
+    with engine.begin() as conn:
+        sql = ARQUIVO_ESQUEMA.read_text(encoding="utf-8")
+        conn.execute(text(sql))
+
+
+def popular_basicos(engine):
+    """Insere registros básicos como tipos de energia e raridades."""
+    with engine.begin() as conn:
+        for nome, simbolo in ENERGIAS:
+            conn.execute(
+                text(
+                    "INSERT INTO tipos_energia (nome, simbolo) VALUES (:nome, :simbolo) "
+                    "ON CONFLICT (nome) DO NOTHING"
+                ),
+                {"nome": nome, "simbolo": simbolo},
+            )
+        for nome in RARIDADES:
+            conn.execute(
+                text(
+                    "INSERT INTO raridades (nome) VALUES (:nome) ON CONFLICT (nome) DO NOTHING"
+                ),
+                {"nome": nome},
+            )
+
+
+if __name__ == "__main__":
+    engine = obter_engine()
+    criar_esquema(engine)
+    popular_basicos(engine)
+    print("Esquema criado e dados básicos inseridos com sucesso.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.32.3
 APScheduler==3.10.4
 beautifulsoup4==4.12.3
 pydantic==2.7.4
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## Resumo
- Define esquema SQL completo em português para o Pokémon TCG
- Inclui script `popular_bd.py` para criar o esquema e inserir dados básicos
- Adiciona dependência `psycopg2-binary` para conexão com PostgreSQL

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b27631a2608324a8b4e7c6be2c010e