### PR TITLE
Centralize SQLite path in instance directory

### DIFF
--- a/seed_demo.py
+++ b/seed_demo.py
@@ -1,22 +1,19 @@
-# scripts/seed_demo.py
-"""
-Seed de dados DEMO para o dashboard.
-Cria algumas linhas no banco com preços sintéticos, só para validar UI.
+"""seed_demo.py
+-----------------
+Popula o banco com dados sintéticos para demonstração do dashboard.
 
-Como usar:
-    # no terminal, na raiz do projeto
-    # (garanta que o venv está ativo)
-    python scripts/seed_demo.py
+Executar na raiz do projeto com o ambiente virtual ativado:
+
+    python seed_demo.py
 """
 
 from __future__ import annotations
+
 from datetime import datetime, timedelta
 import random
 
-from flask import Flask
-
-from config import DB_URL
-from db import DB, Price
+from app import create_app
+from db import db, Set, Card, PriceHistory
 
 TERMS = [
     "Charizard 4/102",
@@ -26,40 +23,43 @@ TERMS = [
     "Miraidon ex",
 ]
 
-SOURCES = ["pricecharting", "ebay"]  # mantém “ebay” só para compor o snapshot
-
-
-def _mk_app() -> Flask:
-    app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = DB_URL
-    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-    DB.init_app(app)
-    return app
+SOURCES = ["pricecharting", "ebay"]
 
 
 def _rand_price(base: float, spread: float = 0.15) -> tuple[float, float]:
-    """
-    Gera (min, max) ao redor de um 'base' com certa variação percentual.
-    """
+    """Gera (min, max) ao redor de um ``base`` com certa variação percentual."""
+
     jitter = 1 + random.uniform(-spread, spread)
     mid = base * jitter
-    lo = mid * (1 - 0.06 - random.uniform(0, 0.05))   # ~6–11% abaixo
-    hi = mid * (1 + 0.06 + random.uniform(0, 0.05))   # ~6–11% acima
+    lo = mid * (1 - 0.06 - random.uniform(0, 0.05))
+    hi = mid * (1 + 0.06 + random.uniform(0, 0.05))
     lo, hi = round(max(1.0, lo), 2), round(max(lo + 0.01, hi), 2)
     return lo, hi
 
 
 def main() -> None:
-    app = _mk_app()
+    app = create_app()
     with app.app_context():
-        DB.create_all()
+        db.create_all()
 
         now = datetime.utcnow()
 
-        # limpa um pouco (opcional): comente se não quiser apagar nada
-        # DB.session.query(Price).delete()
+        # cria set e cartas básicas para associar valores
+        demo_set = Set.query.filter_by(code="demo").first()
+        if demo_set is None:
+            demo_set = Set(name="Demo", code="demo")
+            db.session.add(demo_set)
+            db.session.flush()
 
-        rows = []
+        cards: dict[str, Card] = {}
+        for i, term in enumerate(TERMS, start=1):
+            card = Card.query.filter_by(set_id=demo_set.id, name=term).first()
+            if card is None:
+                card = Card(name=term, number=str(i), set_id=demo_set.id)
+                db.session.add(card)
+                db.session.flush()
+            cards[term] = card
+
         base_map = {
             "Charizard 4/102": 1500.0,
             "Pikachu": 45.0,
@@ -68,29 +68,34 @@ def main() -> None:
             "Miraidon ex": 80.0,
         }
 
-        for i, term in enumerate(TERMS):
+        rows: list[PriceHistory] = []
+        for term in TERMS:
             base = base_map.get(term, 50.0)
-
-            # gera 8 pontos históricos pra cada fonte, espaçados no tempo
+            card = cards[term]
             for src in SOURCES:
                 for k in range(8):
                     t = now - timedelta(days=7 - k, hours=random.randint(0, 12))
-                    lo, hi = _rand_price(base * (1 + (k - 4) * 0.02))  # leve tendência
-                    p = Price(
-                        query=term,
-                        source=src,
-                        title=f"{term} — demo ({src})",
-                        url="https://example.org/demo",
-                        price_min_brl=lo,
-                        price_max_brl=hi,
-                        captured_at=t,
+                    lo, hi = _rand_price(base * (1 + (k - 4) * 0.02))
+                    mid = (lo + hi) / 2.0
+                    rows.append(
+                        PriceHistory(
+                            card_id=card.id,
+                            price=mid,
+                            source=src,
+                            captured_at=t,
+                        )
                     )
-                    rows.append(p)
 
-        DB.session.add_all(rows)
-        DB.session.commit()
-        print(f"[seed_demo] Inseridos {len(rows)} registros em {len(TERMS)} termos / {len(SOURCES)} fontes.")
-        print("[seed_demo] Abra: http://localhost:5000/  — e clique em algum termo do snapshot.")
+        db.session.add_all(rows)
+        db.session.commit()
+        print(
+            f"[seed_demo] Inseridos {len(rows)} registros para {len(TERMS)} cartas demo."
+        )
+        print(
+            "[seed_demo] Abra: http://localhost:5000/  — e clique em algum termo do snapshot."
+        )
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- Resolve DB URIs inside `instance/` and create the directory automatically
- Let the Flask factory use `Config.SQLALCHEMY_DATABASE_URI` without overrides
- Update demo seeding script to use `create_app` and new DB models

## Testing
- `python -m py_compile config.py app.py seed_demo.py`
- `python - <<'PY'
from config import Config
print('URI:', Config.SQLALCHEMY_DATABASE_URI)
print('Instance exists:', __import__('os').path.isdir('instance'))
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4f510704c8324a0607f3f67701d9d