### PR TITLE
Expand card metadata with attacks and abilities

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,8 +171,12 @@ def create_app() -> Flask:
         progress = []
         for s in sets:
             set_total = (
-                db.session.query(func.count(Card.id)).filter(Card.set_id == s.id).scalar()
-                or 0
+                s.total_cards
+                if s.total_cards is not None
+                else (
+                    db.session.query(func.count(Card.id)).filter(Card.set_id == s.id).scalar()
+                    or 0
+                )
             )
             owned_distinct = (
                 db.session.query(func.count(distinct(CollectionItem.card_id)))


### PR DESCRIPTION
## Summary
- track set `series` and `total_cards`
- store rich card details (hp, category, subtypes, evolution, illustrator, weaknesses, resistances, retreat cost, flavor text)
- add `card_attacks` and `card_abilities` tables with relationships
- include new fields in JSON serialisation and dashboard counts

## Testing
- `python -m py_compile db.py app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5066ec8c4832493245251b440df26