### PR TITLE
Expose card metadata filters and export

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -59,7 +59,7 @@
 
   <!-- BUSCAR POR NOME -->
   <form method="get" action="{{ url_for('cards') }}" class="card p-3 mb-4">
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+    <div class="grid grid-cols-1 md:grid-cols-7 gap-3">
       <div class="md:col-span-2">
         <label class="text-xs text-slate-600">Buscar por nome</label>
         <input
@@ -92,6 +92,31 @@
         </select>
       </div>
 
+      <div>
+        <label class="text-xs text-slate-600">Série</label>
+        <select name="series" class="w-full">
+          <option value="">Todas</option>
+          {% for s in series_list %}
+            <option value="{{ s }}" {% if (series or '') == s %}selected{% endif %}>{{ s }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <div>
+        <label class="text-xs text-slate-600">Categoria</label>
+        <select name="category" class="w-full">
+          <option value="">Todas</option>
+          {% for c in categories %}
+            <option value="{{ c }}" {% if (category or '') == c %}selected{% endif %}>{{ c }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <div>
+        <label class="text-xs text-slate-600">HP</label>
+        <input type="number" name="hp" value="{{ hp or '' }}" class="w-full">
+      </div>
+
       <div class="md:col-span-2 flex items-end gap-3">
         <label class="inline-flex items-center gap-2">
           <input type="checkbox" name="only_missing" {% if only_missing %}checked{% endif %}>
@@ -111,6 +136,9 @@
         {% if q %} para <b>"{{ q }}"</b>{% endif %}
         {% if set_id %} • Set filtrado{% endif %}
         {% if rarity %} • Raridade: {{ rarity }}{% endif %}
+        {% if series %} • Série: {{ series }}{% endif %}
+        {% if category %} • Categoria: {{ category }}{% endif %}
+        {% if hp %} • HP: {{ hp }}{% endif %}
         {% if only_missing %} • Apenas não possuídas{% endif %}
       </div>
     </div>
@@ -129,8 +157,15 @@
           <div class="mt-3">
             <h3 class="font-semibold leading-tight truncate" title="{{ c.name }}">{{ c.name }}</h3>
             <p class="text-xs text-slate-500 truncate">
-              {% if c.set %}<a href="{{ url_for('set_view', set_id=c.set.id) }}" class="underline hover:no-underline">{{ c.set.name }}</a>{% else %}—{% endif %} • #{{ c.number or '—' }}{% if c.rarity %} • {{ c.rarity }}{% endif %}
+              {% if c.set %}<a href="{{ url_for('set_view', set_id=c.set.id) }}" class="underline hover:no-underline">{{ c.set.name }}</a>{% else %}—{% endif %} • #{{ c.number or '—' }}{% if c.rarity %} • {{ c.rarity }}{% endif %}{% if c.hp %} • HP {{ c.hp }}{% endif %}{% if c.category %} • {{ c.category }}{% endif %}
             </p>
+            {% if c.attacks %}
+              <ul class="mt-1 text-[11px] text-slate-500 leading-tight">
+                {% for a in c.attacks %}
+                  <li>{{ a.name }}{% if a.damage %} — {{ a.damage }}{% endif %}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
           </div>
 
           <form action="{{ url_for('collection_add') }}" method="post" class="mt-3 grid grid-cols-6 gap-2 items-end">

--- a/templates/set_detail.html
+++ b/templates/set_detail.html
@@ -76,7 +76,14 @@
 
         <div class="mt-3">
           <h3 class="font-semibold leading-tight truncate" title="{{ c.name }}">{{ c.name }}</h3>
-          <p class="text-xs text-slate-500 truncate">#{{ c.number or '—' }}{% if c.rarity %} • {{ c.rarity }}{% endif %}</p>
+          <p class="text-xs text-slate-500 truncate">#{{ c.number or '—' }}{% if c.rarity %} • {{ c.rarity }}{% endif %}{% if c.hp %} • HP {{ c.hp }}{% endif %}{% if c.category %} • {{ c.category }}{% endif %}</p>
+          {% if c.attacks %}
+            <ul class="mt-1 text-[11px] text-slate-500 leading-tight">
+              {% for a in c.attacks %}
+                <li>{{ a.name }}{% if a.damage %} — {{ a.damage }}{% endif %}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
         </div>
       </article>
     {% endfor %}

--- a/templates/sets.html
+++ b/templates/sets.html
@@ -28,6 +28,7 @@
                       <h3 class="font-semibold truncate" title="<a href="{{ url_for('set_view', set_id=s.id) }}" class="underline hover:no-underline">{{ s.name }}</a>"><a href="{{ url_for('set_view', set_id=s.id) }}" class="underline hover:no-underline">{{ s.name }}</a></h3>
                       <p class="text-xs text-slate-500">
                         Código: {{ s.code or '—' }}
+                        {% if s.series %} • Série: {{ s.series }}{% endif %}
                         {% if s.release_date %} • Lançamento: {{ s.release_date.strftime('%d/%m/%Y') }}{% endif %}
                       </p>
                     </div>


### PR DESCRIPTION
## Summary
- allow filtering cards by series, category or HP
- show HP, category and attacks in card listings
- include extra metadata in card CSV export

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b50a4cdab08324b55599c7fa6e7bff