### PR TITLE
Add physical card attributes for Portuguese TCG cards

### DIFF
--- a/db.py
+++ b/db.py
@@ -100,6 +100,11 @@ class Card(db.Model):
     resistances: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(db.JSON)
     retreat_cost: Mapped[Optional[List[str]]] = mapped_column(db.JSON)
     flavor_text: Mapped[Optional[str]] = mapped_column(db.Text)
+    language: Mapped[Optional[str]] = mapped_column(db.String(20))
+    border: Mapped[Optional[str]] = mapped_column(db.String(20))
+    holo: Mapped[Optional[str]] = mapped_column(db.String(30))
+    material: Mapped[Optional[str]] = mapped_column(db.String(30))
+    edition: Mapped[Optional[str]] = mapped_column(db.String(30))
 
     set_id: Mapped[int] = mapped_column(
         ForeignKey("sets.id", ondelete="CASCADE"), nullable=False, index=True
@@ -153,6 +158,11 @@ class Card(db.Model):
             "resistances": self.resistances,
             "retreat_cost": self.retreat_cost,
             "flavor_text": self.flavor_text,
+            "language": self.language,
+            "border": self.border,
+            "holo": self.holo,
+            "material": self.material,
+            "edition": self.edition,
             "attacks": [a.as_dict() for a in self.attacks],
             "abilities": [a.as_dict() for a in self.abilities],
             "set": self.set.as_dict() if self.set else None,

--- a/scrapers/tcgdex_import.py
+++ b/scrapers/tcgdex_import.py
@@ -168,6 +168,7 @@ def save_card_to_db(card_data: Dict[str, Any]) -> None:
         or (card_data.get("images") or {}).get("large")
         or (card_data.get("images") or {}).get("small")
     )
+    card.language = card_data.get("language") or "português"
 
     prices = card_data.get("prices")
     price_value = _extract_price(prices)

--- a/seed_ligapokemon_cards.py
+++ b/seed_ligapokemon_cards.py
@@ -69,6 +69,11 @@ def process_edid(edid: str, delay_s: float = 0.8) -> None:
             "image_url": ("image", "image_url", "imagem"),
             "hp": ("hp",),
             "category": ("categoria", "category"),
+            "language": ("language", "idioma"),
+            "border": ("border", "borda"),
+            "holo": ("holo",),
+            "material": ("material",),
+            "edition": ("edition", "edicao"),
         }
         for attr, keys in mapping.items():
             for k in keys:
@@ -76,6 +81,9 @@ def process_edid(edid: str, delay_s: float = 0.8) -> None:
                 if v:
                     setattr(card, attr, v)
                     break
+
+        if not getattr(card, "language", None):
+            card.language = "português"
 
     set_obj.total_cards = len(cards)
     db.session.commit()


### PR DESCRIPTION
## Summary
- store physical card attributes on `Card` model
- import Liga Pokémon card fields like border, holo and edition
- default Portuguese language during TCGdex imports

## Testing
- `python -m py_compile db.py scrapers/tcgdex_import.py seed_ligapokemon_cards.py`


------
https://chatgpt.com/codex/tasks/task_e_68b675d794948324bbbe9380ff63d684