### PR TITLE
Fix TCGdex seeding image handling

### DIFF
--- a/seed_tcgdex_cards.py
+++ b/seed_tcgdex_cards.py
@@ -51,10 +51,6 @@ def _import_sets(set_ids: Optional[Iterable[str]] = None) -> None:
     """Importa sets e cartas usando a API TCGdex."""
     if set_ids:
         sets_data = _resolve_sets(set_ids)
-def _import_sets(set_ids: Optional[Iterable[str]] = None) -> None:
-    """Importa sets e cartas usando a API TCGdex."""
-    if set_ids:
-        sets_data = [tcgdex_import.get_set(sid) for sid in set_ids]
     else:
         # lista básica de sets e busca detalhada de cada um
         sets_list = tcgdex_import.get_all_sets()


### PR DESCRIPTION
## Summary
- fix duplicate logic in TCGdex seeding script
- correctly extract card image URL from API data

## Testing
- `python -m py_compile scrapers/tcgdex_import.py seed_tcgdex_cards.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b684171ba08324806a5a42ca1e1c5e