### PR TITLE
Import extended TCGdex metadata

### DIFF
--- a/db.py
+++ b/db.py
@@ -105,6 +105,7 @@ class Card(db.Model):
     holo: Mapped[Optional[str]] = mapped_column(db.String(30))
     material: Mapped[Optional[str]] = mapped_column(db.String(30))
     edition: Mapped[Optional[str]] = mapped_column(db.String(30))
+    legalities: Mapped[Optional[Dict[str, Any]]] = mapped_column(db.JSON)
 
     set_id: Mapped[int] = mapped_column(
         ForeignKey("sets.id", ondelete="CASCADE"), nullable=False, index=True
@@ -163,6 +164,7 @@ class Card(db.Model):
             "holo": self.holo,
             "material": self.material,
             "edition": self.edition,
+            "legalities": self.legalities,
             "attacks": [a.as_dict() for a in self.attacks],
             "abilities": [a.as_dict() for a in self.abilities],
             "set": self.set.as_dict() if self.set else None,


### PR DESCRIPTION
## Summary
- add legalities column to Card model
- populate sets with series and total cards from TCGdex
- persist detailed card info, attacks and abilities

## Testing
- `python -m py_compile db.py scrapers/tcgdex_import.py seed_tcgdex_cards.py`
- `python seed_tcgdex_cards.py --sets base1` *(fails: Unable to connect to proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6859a55648324aa002570eb8c059f