### PR TITLE
Handle dictionary series values from tcgdex API

### DIFF
--- a/scrapers/tcgdex_import.py
+++ b/scrapers/tcgdex_import.py
@@ -104,6 +104,8 @@ def _find_or_create_set(set_data: Dict[str, Any]) -> Set:
 
     series = set_data.get("serie") or set_data.get("series")
     if series:
+        if isinstance(series, dict):
+            series = series.get("name") or series.get("id") or str(series)
         set_obj.series = series
 
     total_cards = set_data.get("total") or set_data.get("totalCards")
@@ -155,6 +157,8 @@ def upsert_set(tcgdex_set: Dict[str, Any]) -> Set:
 
     series = tcgdex_set.get("serie") or tcgdex_set.get("series")
     if series:
+        if isinstance(series, dict):
+            series = series.get("name") or series.get("id") or str(series)
         set_obj.series = series
 
     total_cards = tcgdex_set.get("total") or tcgdex_set.get("totalCards")


### PR DESCRIPTION
## Summary
- ensure tcgdex set imports store only string series values
- normalize series entries derived from API dictionaries

## Testing
- `python -m pytest`
- `python seed_tcgdex_cards.py --sets base1` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b68ac9f6888324aa0297870ed351ec