### PR TITLE
Baixar imagens de cartas localmente

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -148,7 +148,11 @@
         <article class="card p-3">
           <div class="relative">
             {% if c.image_url %}
-              <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+              {% if c.image_url.startswith('http') %}
+                <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+              {% else %}
+                <img src="{{ url_for('static', filename=c.image_url) }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+              {% endif %}
             {% else %}
               <div class="w-full aspect-[3/4] rounded-xl" style="background:#dfecc4; display:grid; place-items:center; color:#2c452c;">sem imagem</div>
             {% endif %}

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -18,7 +18,11 @@
           <!-- Imagem -->
           <div class="relative">
             {% if c and c.image_url %}
-              <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+              {% if c.image_url.startswith('http') %}
+                <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+              {% else %}
+                <img src="{{ url_for('static', filename=c.image_url) }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+              {% endif %}
             {% else %}
               <div class="w-full aspect-[3/4] rounded-xl" style="background:#dfecc4; display:grid; place-items:center; color:#2c452c;">sem imagem</div>
             {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -141,9 +141,15 @@
         <article class="card p-2">
           <div class="relative">
             {% if i.card.image_url %}
-              <img src="{{ i.card.image_url }}"
-                   alt="Imagem de {{ i.card.name }}"
-                   class="w-full aspect-[3/4] object-cover rounded-lg">
+              {% if i.card.image_url.startswith('http') %}
+                <img src="{{ i.card.image_url }}"
+                     alt="Imagem de {{ i.card.name }}"
+                     class="w-full aspect-[3/4] object-cover rounded-lg">
+              {% else %}
+                <img src="{{ url_for('static', filename=i.card.image_url) }}"
+                     alt="Imagem de {{ i.card.name }}"
+                     class="w-full aspect-[3/4] object-cover rounded-lg">
+              {% endif %}
             {% else %}
               <div class="w-full aspect-[3/4] bg-slate-200 rounded-lg grid place-items-center text-slate-500">
                 sem imagem

--- a/templates/set_detail.html
+++ b/templates/set_detail.html
@@ -60,7 +60,11 @@
 
         <div class="relative mt-2">
           {% if c.image_url %}
-            <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+            {% if c.image_url.startswith('http') %}
+              <img src="{{ c.image_url }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+            {% else %}
+              <img src="{{ url_for('static', filename=c.image_url) }}" alt="Imagem de {{ c.name }}" class="w-full aspect-[3/4] object-cover rounded-xl">
+            {% endif %}
           {% else %}
             <div class="w-full aspect-[3/4] rounded-xl" style="border:1px dashed #d9e6d9; background:linear-gradient(120deg,#f8fcf8,#f1f6f1); display:grid; place-items:center; color:#2c452c;">sem imagem</div>
           {% endif %}

--- a/templates/wishlist.html
+++ b/templates/wishlist.html
@@ -18,7 +18,11 @@
         <article class="card p-3">
           <div class="flex gap-3">
             {% if i.card.image_url %}
-              <img src="{{ i.card.image_url }}" alt="Imagem de {{ i.card.name }}" class="w-16 h-20 object-cover rounded">
+              {% if i.card.image_url.startswith('http') %}
+                <img src="{{ i.card.image_url }}" alt="Imagem de {{ i.card.name }}" class="w-16 h-20 object-cover rounded">
+              {% else %}
+                <img src="{{ url_for('static', filename=i.card.image_url) }}" alt="Imagem de {{ i.card.name }}" class="w-16 h-20 object-cover rounded">
+              {% endif %}
             {% else %}
               <div class="w-16 h-20 bg-slate-200 rounded grid place-items-center text-slate-500 text-xs">sem<br>img</div>
             {% endif %}


### PR DESCRIPTION
## Summary
- Baixa imagens das cartas da TCGdex e salva em `static/cards/<id>.jpg`
- Usa URL remota como placeholder quando o download falha
- Atualiza templates para exibir imagens locais ou remotas conforme disponível

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68b69a860b888324877d8b79a08bea40