### PR TITLE
Improve tcgdex image download fallbacks

### DIFF
--- a/scrapers/tcgdex_import.py
+++ b/scrapers/tcgdex_import.py
@@ -261,7 +261,13 @@ def save_card_to_db(card_data: Dict[str, Any]) -> None:
         urls_to_try = [image_url]
         base_url = image_url.split("?")[0]
         if not base_url.lower().endswith((".png", ".jpg", ".jpeg")):
-            urls_to_try.extend([f"{image_url}.png", f"{image_url}.jpg"])
+            urls_to_try.extend([f"{base_url}.png", f"{base_url}.jpg"])
+            if "assets.tcgdex.net" in base_url:
+                path = base_url.split("assets.tcgdex.net")[-1]
+                urls_to_try.extend([
+                    f"https://tcgdex.dev/assets{path}.png?ref=assets.tcgdex.net",
+                    f"https://tcgdex.dev/assets{path}.jpg?ref=assets.tcgdex.net",
+                ])
         last_exc: RequestException | None = None
         for url in urls_to_try:
             try:


### PR DESCRIPTION
## Summary
- Try .png/.jpg permutations and new tcgdex.dev host when card images are missing extensions

## Testing
- `python -m py_compile scrapers/tcgdex_import.py`
- `python seed_tcgdex_cards.py --sets A1` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cdc356ac83249e566f217031289f