### PR TITLE
Fix TCGdex image URL path for cards

### DIFF
--- a/scrapers/tcgdex_import.py
+++ b/scrapers/tcgdex_import.py
@@ -161,8 +161,6 @@ def build_card_image_url(
 ) -> str:
     """Build the card image URL using TCGdex's new asset structure."""
     card_id = str(card_id)
-    if card_id.isdigit():
-        card_id = card_id.zfill(3)
     return f"https://assets.tcgdex.net/{lang}/{serie}/{set_id}/{card_id}/{quality}.{extension}"
 
 
@@ -266,7 +264,9 @@ def save_card_to_db(card_data: Dict[str, Any]) -> None:
 
     lang = card_data.get("language") or "pt-br"
     set_code = set_info.get("id") or ""
-    image_url = build_card_image_url(lang, serie_id, set_code, str(number))
+    image_url = card_data.get("image_url") or build_card_image_url(
+        lang, serie_id, set_code, str(number)
+    )
 
     db.session.flush()  # garante que card.id exista para salvar a imagem
     local_dir = Path("static/cards")

--- a/seed_tcgdex_cards.py
+++ b/seed_tcgdex_cards.py
@@ -65,6 +65,12 @@ def _import_sets(set_ids: Optional[Iterable[str]] = None) -> None:
         print(f"[seed_tcgdex_cards] {set_obj.name}: {len(cards)} cartas")
         for card in cards:
             try:
+                lang = "pt-br"
+                series_id = card.get("set", {}).get("serie", {}).get("id")
+                set_id = card.get("set", {}).get("id")
+                card_id = card.get("localId")
+                image_url = f"https://assets.tcgdex.net/{lang}/{series_id}/{set_id}/{card_id}/high.png"
+                card["image_url"] = image_url
                 tcgdex_import.save_card_to_db(card)
             except Exception as exc:  # noqa: BLE001
                 db.session.rollback()


### PR DESCRIPTION
## Summary
- Build TCGdex card image URL using new `{lang}/{series}/{set}/{card}/high.png` format
- Load precomputed image URLs when saving cards to avoid 404s

## Testing
- `python -m py_compile seed_tcgdex_cards.py scrapers/tcgdex_import.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b75a7b981c8324899adac8f0c0dd44