### PR TITLE
feat: import tcgdex cards database

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.32.3
 APScheduler==3.10.4
 beautifulsoup4==4.12.3
 pydantic==2.7.4
+json5==0.9.25

--- a/seed_tcgdex_cards.py
+++ b/seed_tcgdex_cards.py
@@ -1,22 +1,25 @@
 """seed_tcgdex_cards.py
 ---------------------------------
-Seed de cartas utilizando os arquivos JSON locais do repositório tcgdex/distribution.
+Seed de cartas utilizando os arquivos locais do repositório `tcgdex`.
+Suporta tanto o formato JSON da `tcgdex/distribution` quanto os arquivos
+TypeScript da `tcgdex/cards-database`.
 
 Uso:
     python seed_tcgdex_cards.py                               # importa todos os sets
-    python seed_tcgdex_cards.py --sets base1 sv1               # por ID do set
-    python seed_tcgdex_cards.py --sets "rivais predestinados"  # por nome
-    python seed_tcgdex_cards.py --data-dir ../tcgdex-distribution  # caminho dos JSONs
+    python seed_tcgdex_cards.py --sets base4                   # por ID do set
+    python seed_tcgdex_cards.py --sets "Base Set 2"           # por nome
+    python seed_tcgdex_cards.py --data-dir ../cards-database   # caminho dos dados
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import json5
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from app import create_app
 from db import db
@@ -90,11 +93,30 @@ def _gather_cards(cards_root: Path, set_id: str) -> list[Path]:
 
 
 # ---------------------------------------------------------------------------
+# Parsing helpers for cards-database (.ts) files
+
+
+def _parse_ts_object(content: str) -> Dict[str, Any]:
+    """Converte um objeto TypeScript simples em dict Python."""
+    # Remove imports e export
+    content = re.sub(r"^import[^\n]*\n", "", content, flags=re.MULTILINE)
+    content = re.sub(r"export default [^\n]*", "", content)
+    # Remove declarações "const foo: Tipo ="
+    content = re.sub(r"const [^=]+=", "", content)
+    # Remove referência direta ao objeto Set dentro das cartas
+    content = re.sub(r"\n?\s*set:\s*Set,?", "", content)
+    content = content.strip()
+    return json5.loads(content)
+
+
+# ---------------------------------------------------------------------------
 # Importação
 
 
-def _import_sets(data_dir: Path, set_ids: Optional[Iterable[str]] = None, lang: str = "pt") -> None:
-    """Importa sets e cartas usando os arquivos locais."""
+def _import_from_distribution(
+    data_dir: Path, set_ids: Optional[Iterable[str]] = None, lang: str = "pt"
+) -> None:
+    """Importa sets e cartas usando os arquivos JSON da tcgdex/distribution."""
     data_root = data_dir / "v2"
     lang_dir = data_root / lang
     cards_root = lang_dir / "cards"
@@ -157,6 +179,79 @@ def _import_sets(data_dir: Path, set_ids: Optional[Iterable[str]] = None, lang: 
             print(f"Erro ao commitar set {set_obj.name}: {exc}")
 
 
+def _import_from_cardsdb(
+    data_dir: Path, set_ids: Optional[Iterable[str]] = None, lang: str = "en"
+) -> None:
+    """Importa dados diretamente do repositório tcgdex/cards-database."""
+    data_root = data_dir / "data"
+    if not data_root.exists():
+        print(f"Diretório de dados não encontrado em {data_root}")
+        return
+
+    # Mapeia séries para obter seus IDs
+    series_map: Dict[str, str] = {}
+    for serie_file in data_root.glob("*.ts"):
+        serie_name = serie_file.stem
+        serie_data = _parse_ts_object(serie_file.read_text())
+        serie_id = serie_data.get("id") or serie_name.lower()
+        series_map[serie_name] = serie_id
+
+    for serie_dir in data_root.iterdir():
+        if not serie_dir.is_dir():
+            continue
+        serie_name = serie_dir.name
+        serie_id = series_map.get(serie_name, "")
+
+        for set_file in serie_dir.glob("*.ts"):
+            set_name = set_file.stem
+            set_data = _parse_ts_object(set_file.read_text())
+            sid = set_data.get("id")
+            if not sid:
+                continue
+            if set_ids and sid not in set_ids and _slugify(set_name) not in set_ids:
+                continue
+
+            set_info = {
+                "id": sid,
+                "name": set_data.get("name", {}).get(lang)
+                or next(iter(set_data.get("name", {}).values()), ""),
+                "serie": serie_id,
+            }
+            set_obj = tcgdex_import.upsert_set(set_info)
+
+            card_dir = serie_dir / set_name
+            card_files = list(card_dir.glob("*.ts")) if card_dir.exists() else []
+            print(f"[seed_tcgdex_cards] {set_obj.name}: {len(card_files)} cartas")
+            for card_path in card_files:
+                number = card_path.stem
+                card_data = _parse_ts_object(card_path.read_text())
+                card_data["localId"] = number
+                card_data["id"] = f"{sid}-{number}"
+                card_data["set"] = set_info
+                card_data["language"] = lang
+                card_data["image_url"] = tcgdex_import.build_card_image_url(
+                    lang, serie_id, sid, number
+                )
+                try:
+                    tcgdex_import.save_card_to_db(card_data)
+                except Exception as exc:  # noqa: BLE001
+                    db.session.rollback()
+                    print(f"Erro ao importar carta {card_data.get('id')}: {exc}")
+            try:
+                db.session.commit()
+            except Exception as exc:  # noqa: BLE001
+                db.session.rollback()
+                print(f"Erro ao commitar set {set_obj.name}: {exc}")
+
+
+def _import_sets(data_dir: Path, set_ids: Optional[Iterable[str]] = None, lang: str = "pt") -> None:
+    """Seleciona a estratégia de importação conforme a estrutura do diretório."""
+    if (data_dir / "v2").exists():
+        _import_from_distribution(data_dir, set_ids, lang)
+    else:
+        _import_from_cardsdb(data_dir, set_ids, lang)
+
+
 # ---------------------------------------------------------------------------
 # CLI
 
@@ -172,13 +267,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--lang",
-        default="pt",
+        default="en",
         help="Idioma dos dados (ex: en, pt)",
     )
     parser.add_argument(
         "--data-dir",
-        default="../tcgdex-distribution",
-        help="Caminho para o repositório local tcgdex/distribution",
+        default="../cards-database",
+        help="Caminho para o repositório local tcgdex/cards-database ou distribution",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- support seeding from tcgdex/cards-database TypeScript files
- add json5 dependency for parsing TS data

## Testing
- `pip install -r requirements.txt`
- `python seed_tcgdex_cards.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b77bbae77c8324a6c1da1ce314f59e