### PR TITLE
Refactor seeding to handle localized card data

### DIFF
--- a/db.py
+++ b/db.py
@@ -183,10 +183,10 @@ class CardAttack(db.Model):
     card_id: Mapped[int] = mapped_column(
         ForeignKey("cards.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    name: Mapped[Dict[str, Any]] = mapped_column(db.JSON, nullable=False)
+    name: Mapped[str] = mapped_column(db.String(200), nullable=False)
     cost: Mapped[Optional[List[str]]] = mapped_column(db.JSON)
     damage: Mapped[Optional[str]] = mapped_column(db.String(50))
-    text: Mapped[Optional[Dict[str, Any]]] = mapped_column(db.JSON)
+    text: Mapped[Optional[str]] = mapped_column(db.Text)
 
     created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
@@ -214,10 +214,10 @@ class CardAbility(db.Model):
     card_id: Mapped[int] = mapped_column(
         ForeignKey("cards.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    name: Mapped[Dict[str, Any]] = mapped_column(db.JSON, nullable=False)
+    name: Mapped[str] = mapped_column(db.String(200), nullable=False)
     cost: Mapped[Optional[List[str]]] = mapped_column(db.JSON)
     damage: Mapped[Optional[str]] = mapped_column(db.String(50))
-    text: Mapped[Optional[Dict[str, Any]]] = mapped_column(db.JSON)
+    text: Mapped[Optional[str]] = mapped_column(db.Text)
 
     created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(

--- a/seed_tcgdex_cards.py
+++ b/seed_tcgdex_cards.py
@@ -8,7 +8,6 @@ TypeScript da `tcgdex/cards-database`.
 from __future__ import annotations
 
 import argparse
-import json
 import json5
 import re
 from pathlib import Path
@@ -60,15 +59,8 @@ def _process_and_save_card(
     card_data["set"].setdefault("id", sid)
     card_data["set"].setdefault("name", set_info.get("name"))
 
-    # Prevent database errors by converting multilingual dicts to JSON strings
-    if isinstance(card_data.get('name'), dict):
-        card_data['name'] = json.dumps(card_data['name'], ensure_ascii=False)
-    if 'attacks' in card_data and card_data['attacks']:
-        for attack in card_data['attacks']:
-            if isinstance(attack.get('name'), dict):
-                attack['name'] = json.dumps(attack['name'], ensure_ascii=False)
-            if isinstance(attack.get('text'), dict):
-                attack['text'] = json.dumps(attack['text'], ensure_ascii=False)
+    # Language resolution happens in ``save_card_to_db``,
+    # so we keep multilingual fields as dictionaries.
 
     card_data["language"] = lang
     card_data["image_url"] = tcgdex_import.build_card_image_url(


### PR DESCRIPTION
## Summary
- store attack and ability names/text as strings in the database
- resolve localized strings when importing cards from tcgdex data
- simplify seed script to rely on localization during save

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python seed_tcgdex_cards.py --help`
- `python scripts/load_tcgdex.py --help` *(fails: Parameter.make_metavar() missing 1 required positional argument: 'ctx')*

------
https://chatgpt.com/codex/tasks/task_e_68b8594262fc832482199577492ad65f