### PR TITLE
Fix set field substitution in card seeder

### DIFF
--- a/seed_tcgdex_cards.py
+++ b/seed_tcgdex_cards.py
@@ -25,7 +25,8 @@ def _clean_ts(content: str, set_name: str) -> str:
     content = IMPORT_RE.sub("", content)
     content = content.replace("export default card", "")
     content = content.replace("const card: Card =", "const card =")
-    content = re.sub(r"(\bset\s*:\s*)Set\b", rf"\1\"{set_name}\"", content)
+    # Replace "set: Set" with the actual set name string
+    content = re.sub(r"(\bset\s*:\s*)Set\b", rf'\1"{set_name}"', content)
     # remove prefix/suffix around object
     content = re.sub(r"^\s*const card\s*=\s*", "", content, count=1).strip()
     if content.endswith(";"):


### PR DESCRIPTION
## Summary
- prevent stray backslashes when inserting set name into TypeScript card data

## Testing
- `python seed_tcgdex_cards.py --cards-db-dir tmpcards --limit 1 --clean`


------
https://chatgpt.com/codex/tasks/task_e_68b87a881fe883249aa5f07fc4ac477b