### PR TITLE
Handle undefined card fields in seed script

### DIFF
--- a/seed_tcgdex_cards.py
+++ b/seed_tcgdex_cards.py
@@ -27,6 +27,8 @@ def _clean_ts(content: str, set_name: str) -> str:
     content = content.replace("const card: Card =", "const card =")
     # Replace "set: Set" with the actual set name string
     content = re.sub(r"(\bset\s*:\s*)Set\b", rf'\1"{set_name}"', content)
+    # Replace explicit undefined values with null so json5 can parse them
+    content = re.sub(r":\s*undefined", ": null", content)
     # remove prefix/suffix around object
     content = re.sub(r"^\s*const card\s*=\s*", "", content, count=1).strip()
     if content.endswith(";"):


### PR DESCRIPTION
## Summary
- Normalize `undefined` values to `null` before JSON5 parsing in `seed_tcgdex_cards.py`

## Testing
- `python seed_tcgdex_cards.py --cards-db-dir /tmp/cards-data --clean`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b87cb8e4608324b7650b5cc2011a8b