### PR TITLE
fix: align card database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ pip install -r requirements.txt
 # popula o banco (SQLite local por padrão)
 python seed_tcgdex_cards.py --cards-db-dir ./cards-database --clean
 
-# usando outro banco
-DATABASE_URL=sqlite:///meu.db python seed_tcgdex_cards.py --cards-db-dir ./cards-database
+# usando outro banco (aceita DB_URL, DATABASE_URL ou SQLALCHEMY_DATABASE_URI)
+DB_URL=sqlite:///meu.db python seed_tcgdex_cards.py --cards-db-dir ./cards-database
 ```
 
 O comando acima cria/atualiza a tabela `cards` com os dados dos arquivos

--- a/cards_db.py
+++ b/cards_db.py
@@ -12,10 +12,25 @@ from sqlalchemy.orm import declarative_base
 
 
 def _get_database_url() -> str:
-    url = os.environ.get("DATABASE_URL")
+    """Resolve database URL used for the TCG cards storage.
+
+    The previous implementation relied on the current working directory,
+    which meant executing the seed script from a different folder would
+    create a brand new database elsewhere.  To keep things consistent with
+    the main project, we look for the same environment variables accepted by
+    ``config.py`` and fall back to a path relative to this file.
+    """
+
+    url = (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("DB_URL")
+        or os.environ.get("SQLALCHEMY_DATABASE_URI")
+    )
     if url:
         return url
-    db_path = Path("database/poketcg.db")
+
+    root = Path(__file__).resolve().parent
+    db_path = root / "database" / "poketcg.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
     return f"sqlite:///{db_path.as_posix()}"
 


### PR DESCRIPTION
## Summary
- resolve card database url relative to project
- document DB_URL option for seeding cards

## Testing
- `python -m py_compile cards_db.py seed_tcgdex_cards.py`


------
https://chatgpt.com/codex/tasks/task_e_68b896a6ca908324ada4b570ebc16c9c