### PR TITLE
Fix ensure_ascii issue in cards template

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,6 +124,9 @@ def create_app() -> Flask:
     # Importante: habilita pasta `instance/`
     app = Flask(__name__, instance_relative_config=True)
 
+    # Ensure JSON rendering keeps non-ASCII characters
+    app.jinja_env.policies["json.dumps_kwargs"]["ensure_ascii"] = False
+
     # Carrega config base
     app.config.from_object(Config)
     

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -50,7 +50,7 @@
       <td class="p-2"><button type="button" onclick="toggle('j{{ loop.index }}')" class="text-blue-600 underline">ver JSON</button></td>
     </tr>
     <tr id="j{{ loop.index }}" style="display:none">
-      <td colspan="7" class="p-2"><pre>{{ c.data_json | tojson(indent=2, ensure_ascii=False) }}</pre></td>
+      <td colspan="7" class="p-2"><pre>{{ c.data_json | tojson(indent=2) }}</pre></td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- remove unsupported ensure_ascii arg from cards template tojson filter
- configure Jinja policy to avoid ASCII escaping in JSON

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b89d0f1134832482f575177326e178